### PR TITLE
Remove payment intent metadata from Subscription checkout session

### DIFF
--- a/lib/usage_credits/models/credit_subscription_plan.rb
+++ b/lib/usage_credits/models/credit_subscription_plan.rb
@@ -157,7 +157,6 @@ module UsageCredits
         }],
         success_url: success_url,
         cancel_url: cancel_url,
-        payment_intent_data: { metadata: base_metadata },
         subscription_data: { metadata: base_metadata }
       )
     end


### PR DESCRIPTION
### Why 
Stripe does not allow payment intent metadata for a subscription checkout session. This was causing Stripe to reject the checkout session.

### What
This PR simply removes the line sending the payment intent metadata with the checkout session. This fixes the Stripe error and allows the checkout session to go through.

### Followup
I saw that this method on the credit_subscription_plan is undocumented in the README. We should document this if it's the preferred path, otherwise deprecate if it's preferred to make a normal Pay gem checkout session. (glob options would be nice here to pass in allow_promo_codes etc)