### PR TITLE
credit packs - allow custom payment processor options

### DIFF
--- a/lib/usage_credits/models/credit_pack.rb
+++ b/lib/usage_credits/models/credit_pack.rb
@@ -124,7 +124,7 @@ module UsageCredits
     # =========================================
 
     # Create a Stripe Checkout session for this pack
-    def create_checkout_session(user)
+    def create_checkout_session(user, **options)
       raise ArgumentError, "User must have a payment processor" unless user.respond_to?(:payment_processor) && user.payment_processor
 
       user.payment_processor.checkout(
@@ -141,7 +141,8 @@ module UsageCredits
           quantity: 1
         }],
         payment_intent_data: { metadata: base_metadata },
-        metadata: base_metadata
+        metadata: base_metadata,
+        **options
       )
     end
 


### PR DESCRIPTION
with `**options` now you can pass additional params to the checkout session.

```
session = credit_pack.create_checkout_session(
  current_organization,
  allow_promotion_codes: true,
  success_url: organization_credits_url(current_organization),
  cancel_url: organization_credits_url(current_organization)
)
```

fixes https://github.com/rameerez/usage_credits/issues/3