### PR TITLE
check_low_balance when spending credits

### DIFF
--- a/lib/usage_credits/models/wallet.rb
+++ b/lib/usage_credits/models/wallet.rb
@@ -254,6 +254,8 @@ module UsageCredits
 
       # Fire your existing notifications
       notify_balance_change(:credits_deducted, amount)
+
+      check_low_balance if low_balance?
       spend_tx
     end
   end

--- a/lib/usage_credits/models/wallet.rb
+++ b/lib/usage_credits/models/wallet.rb
@@ -255,7 +255,7 @@ module UsageCredits
       # Fire your existing notifications
       notify_balance_change(:credits_deducted, amount)
 
-      check_low_balance if low_balance?
+      check_low_balance
       spend_tx
     end
   end


### PR DESCRIPTION
currently `check_low_balance` is triggered only on `def add_credits`. 

while we really want to check low balance when spending credits. 

`def deduct_credits` does not `check_low_balance`. 

so there is no way to trigger `on_low_balance` when deducting credits on an operation!

=> this will trigger `on_low_balance` logic when deducting credits. 
